### PR TITLE
Use type map[string]string for environment variables

### DIFF
--- a/engines/duplicity.go
+++ b/engines/duplicity.go
@@ -278,15 +278,15 @@ func (d *DuplicityEngine) launchDuplicity(cmd []string, binds []string) (state i
 	config := d.Orchestrator.GetHandler().Config
 	image := config.Duplicity.Image
 
-	env := []string{
-		"AWS_ACCESS_KEY_ID=" + config.AWS.AccessKeyID,
-		"AWS_SECRET_ACCESS_KEY=" + config.AWS.SecretAccessKey,
-		"SWIFT_USERNAME=" + config.Swift.Username,
-		"SWIFT_PASSWORD=" + config.Swift.Password,
-		"SWIFT_AUTHURL=" + config.Swift.AuthURL,
-		"SWIFT_TENANTNAME=" + config.Swift.TenantName,
-		"SWIFT_REGIONNAME=" + config.Swift.RegionName,
-		"SWIFT_AUTHVERSION=2",
+	env := map[string]string{
+		"AWS_ACCESS_KEY_ID":     config.AWS.AccessKeyID,
+		"AWS_SECRET_ACCESS_KEY": config.AWS.SecretAccessKey,
+		"SWIFT_USERNAME":        config.Swift.Username,
+		"SWIFT_PASSWORD":        config.Swift.Password,
+		"SWIFT_AUTHURL":         config.Swift.AuthURL,
+		"SWIFT_TENANTNAME":      config.Swift.TenantName,
+		"SWIFT_REGIONNAME":      config.Swift.RegionName,
+		"SWIFT_AUTHVERSION":     "2",
 	}
 
 	return d.Orchestrator.LaunchContainer(image, env, cmd, binds)

--- a/engines/rclone_test.go
+++ b/engines/rclone_test.go
@@ -6,19 +6,19 @@ import (
 )
 
 func TestFormatURL(t *testing.T) {
-	checkURL(t, "swift://foo", "swift:foo", []string{})
-	checkURL(t, "s3://foo", "s3:foo", []string{})
-	checkURL(t, "swift://foo/bar", "swift:foo/bar", []string{})
-	checkURL(t, "s3://foo/bar", "s3:foo/bar", []string{})
-	checkURL(t, "s3+http://foo", "s3:foo", []string{})
-	checkURL(t, "s3+http://foo/bar", "s3:foo/bar", []string{})
-	checkURL(t, "s3://sos.io.exo/foo", "s3:foo", []string{"AWS_ENDPOINT=sos.io.exo"})
-	checkURL(t, "s3://sos.io.exo/foo/bar", "s3:foo/bar", []string{"AWS_ENDPOINT=sos.io.exo"})
-	checkURL(t, "s3+http://sos.io.exo/foo", "s3:foo", []string{"AWS_ENDPOINT=sos.io.exo"})
-	checkURL(t, "s3+http://sos.io.exo/foo/bar", "s3:foo/bar", []string{"AWS_ENDPOINT=sos.io.exo"})
+	checkURL(t, "swift://foo", "swift:foo", map[string]string{})
+	checkURL(t, "s3://foo", "s3:foo", map[string]string{})
+	checkURL(t, "swift://foo/bar", "swift:foo/bar", map[string]string{})
+	checkURL(t, "s3://foo/bar", "s3:foo/bar", map[string]string{})
+	checkURL(t, "s3+http://foo", "s3:foo", map[string]string{})
+	checkURL(t, "s3+http://foo/bar", "s3:foo/bar", map[string]string{})
+	checkURL(t, "s3://sos.io.exo/foo", "s3:foo", map[string]string{"AWS_ENDPOINT": "sos.io.exo"})
+	checkURL(t, "s3://sos.io.exo/foo/bar", "s3:foo/bar", map[string]string{"AWS_ENDPOINT": "sos.io.exo"})
+	checkURL(t, "s3+http://sos.io.exo/foo", "s3:foo", map[string]string{"AWS_ENDPOINT": "sos.io.exo"})
+	checkURL(t, "s3+http://sos.io.exo/foo/bar", "s3:foo/bar", map[string]string{"AWS_ENDPOINT": "sos.io.exo"})
 }
 
-func checkURL(t *testing.T, uri, expected string, expectedEnv []string) {
+func checkURL(t *testing.T, uri, expected string, expectedEnv map[string]string) {
 	u, err := url.Parse(uri)
 	if err != nil {
 		t.Fatalf("Failed to parse URL %s", uri)
@@ -35,10 +35,6 @@ func checkURL(t *testing.T, uri, expected string, expectedEnv []string) {
 
 	if len(env) != len(expectedEnv) {
 		t.Fatalf("Expected size %v, got %v", len(expectedEnv), len(env))
-	}
-
-	if env[0] != expectedEnv[0] {
-		t.Fatalf("Expected %v, got %v", expectedEnv, env)
 	}
 	return
 }

--- a/engines/restic.go
+++ b/engines/restic.go
@@ -250,15 +250,15 @@ func (r *ResticEngine) launchRestic(cmd, binds []string) (state int, stdout stri
 	config := r.Orchestrator.GetHandler().Config
 	image := config.Restic.Image
 
-	env := []string{
-		"AWS_ACCESS_KEY_ID=" + config.AWS.AccessKeyID,
-		"AWS_SECRET_ACCESS_KEY=" + config.AWS.SecretAccessKey,
-		"OS_USERNAME=" + config.Swift.Username,
-		"OS_PASSWORD=" + config.Swift.Password,
-		"OS_AUTH_URL=" + config.Swift.AuthURL,
-		"OS_TENANT_NAME=" + config.Swift.TenantName,
-		"OS_REGION_NAME=" + config.Swift.RegionName,
-		"RESTIC_PASSWORD=" + config.Restic.Password,
+	env := map[string]string{
+		"AWS_ACCESS_KEY_ID":     config.AWS.AccessKeyID,
+		"AWS_SECRET_ACCESS_KEY": config.AWS.SecretAccessKey,
+		"OS_USERNAME":           config.Swift.Username,
+		"OS_PASSWORD":           config.Swift.Password,
+		"OS_AUTH_URL":           config.Swift.AuthURL,
+		"OS_TENANT_NAME":        config.Swift.TenantName,
+		"OS_REGION_NAME":        config.Swift.RegionName,
+		"RESTIC_PASSWORD":       config.Restic.Password,
 	}
 
 	return r.Orchestrator.LaunchContainer(image, env, cmd, binds)

--- a/orchestrators/orchestrator.go
+++ b/orchestrators/orchestrator.go
@@ -10,7 +10,7 @@ import (
 type Orchestrator interface {
 	GetHandler() *handler.Conplicity
 	GetVolumes() ([]*volume.Volume, error)
-	LaunchContainer(image string, env []string, cmd []string, binds []string) (state int, stdout string, err error)
+	LaunchContainer(image string, env map[string]string, cmd []string, binds []string) (state int, stdout string, err error)
 	GetMountedVolumes() ([]*volume.MountedVolumes, error)
 	ContainerExec(containerID string, command []string) error
 }


### PR DESCRIPTION
Cleaner and more flexible. Will be useful for the future Kubernetes orchestrator.