### PR TITLE
WIP: Add support for configuring docker network mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Swift Options:
 
 Docker Options:
   -e, --docker-endpoint=            The Docker endpoint. (default: unix:///var/run/docker.sock) [$DOCKER_ENDPOINT]
+  -n, --docker-network=             The Docker network settings. (default: bridge) [$DOCKER_NETWORK]
 
 Kubernetes Options:
       --k8s-namespace=              Namespace where you want to run Bivac. [$K8S_NAMESPACE]

--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,7 @@ type Config struct {
 
 	Docker struct {
 		Endpoint string `short:"e" long:"docker-endpoint" description:"The Docker endpoint." env:"DOCKER_ENDPOINT" default:"unix:///var/run/docker.sock"`
+		Network string `short:"n" long:"docker-network" description:"The Docker network settings." env:"DOCKER_NETWORK" default:"bridge"`
 	} `group:"Docker Options"`
 
 	Kubernetes struct {

--- a/orchestrators/docker.go
+++ b/orchestrators/docker.go
@@ -133,6 +133,8 @@ func (o *DockerOrchestrator) LaunchContainer(image string, env map[string]string
 		},
 		&container.HostConfig{
 			Mounts: mounts,
+			NetworkMode: container.NetworkMode(
+				o.Handler.Config.Docker.Network),
 		}, nil, "",
 	)
 	if err != nil {


### PR DESCRIPTION
See: https://docs.docker.com/engine/reference/run/#network-settings

This PR does not work yet, as for some obscure reason, bivac does not produce any error but is stuck at detecting the provider (which should be the Default provider).
Here is the full debug log:
```
$ docker run -v /var/run/docker.sock:/var/run/docker.sock:ro  --rm -ti -e BIVAC_TARGET_URL=rest:http://restic_rest-server_1:8000/  -e DOCKER_NETWORK=restic_rest-server_1 -e BIVAC_LOG_LEVEL=debug mybivac:latest
INFO[0000] Bivac vv1.0.0-alpha2-5-g439cb26 starting backup... 
DEBU[0000] Detecting orchestrator based on environment... 
DEBU[0000] Using orchestrator: Docker                   
INFO[0000] Ignoring volume                               reason=unnamed source= volume=3a6d31fe1f1aac0a16dbabddd2f25b9373be46a85b0f27daab1831bf5d3097cb
DEBU[0000] Adding event                                  event="bivac_backupStartTime{volume=\"hig_grafana-data\"} 1529410934" metric=bivac_backupStartTime
DEBU[0000] No Pushgateway URL specified, not pushing metrics 
INFO[0000] Detecting provider                            volume=hig_grafana-data
DEBU[0000] Image already pulled, not pulling             image=busybox
DEBU[0000] Creating container                            command="sh -c ([[ -d /media/docker/volumes/hig_grafana-data/_data/mysql ]] && echo 'mysql') || ([[ -f /media/docker/volumes/hig_grafana-data/_data/PG_VERSION ]] && echo 'postgresql') || ([[ -f /media/docker/volumes/hig_grafana-data/_data/DB_CONFIG ]] && echo 'openldap'); return 0" environment= image=busybox
DEBU[0000] Launching with 'sh -c ([[ -d /media/docker/volumes/hig_grafana-data/_data/mysql ]] && echo 'mysql') || ([[ -f /media/docker/volumes/hig_grafana-data/_data/PG_VERSION ]] && echo 'postgresql') || ([[ -f /media/docker/volumes/hig_grafana-data/_data/DB_CONFIG ]] && echo 'openldap'); return 0'...
```
Here is also the docker-compose file I'm using to create the restic rest-server:
```
services:
  rest-server:
    environment:
      DISABLE_AUTHENTICATION: 1
    hostname: restic-rest-server
    image: restic/rest-server
    volumes:
    - ./data:/data
version: '3.1'
```

Any idea why this patch may have a negative influence on the detection of the provider?