### PR TITLE
[WIP] Improve PostgreSQL detection

### DIFF
--- a/providers-config.default.toml
+++ b/providers-config.default.toml
@@ -13,7 +13,7 @@
 	[providers.postgresql]
 	pre_cmd = "mkdir -p $volume/backups && pg_dumpall --clean -Upostgres > $volume/backups/all.sql"
 	post_cmd = ""
-	detect_cmd = "[[ -f $volume/PG_VERSION ]]"
+	detect_cmd = "$(ps auxww | grep -q ^postgres) || [[ -f $volume/PG_VERSION ]]"
 	backup_dir = "backups"
 
 	[providers.openldap]


### PR DESCRIPTION
Bivac will now be able to detect a PostgreSQL even if the file PG_VERSION is not at the root of the volume.
This also add an example of a _complex_ detection command to the default providers-config file.
