### PR TITLE
Templatize arguments

### DIFF
--- a/engines/duplicity.go
+++ b/engines/duplicity.go
@@ -33,6 +33,17 @@ func (*DuplicityEngine) GetName() string {
 	return "Duplicity"
 }
 
+// replaceArgs replace arguments with their values
+func (d *DuplicityEngine) replaceArgs(args []string) (newArgs []string) {
+	log.Debugf("Replacing args, Input: %v", args)
+	for _, arg := range args {
+		arg = strings.Replace(arg, "%T", d.Volume.Target, -1)
+		newArgs = append(newArgs, arg)
+	}
+	log.Debugf("Replacing args, Output: %v", newArgs)
+	return
+}
+
 // Backup performs the backup of the passed volume
 func (d *DuplicityEngine) Backup() (err error) {
 	vol := d.Volume
@@ -102,7 +113,7 @@ func (d *DuplicityEngine) removeOld() (err error) {
 			"--no-encryption",
 			"--force",
 			"--name", v.Name,
-			v.Target,
+			"%T",
 		},
 		[]*volume.Volume{},
 	)
@@ -125,7 +136,7 @@ func (d *DuplicityEngine) cleanup() (err error) {
 			"--force",
 			"--extra-clean",
 			"--name", v.Name,
-			v.Target,
+			"%T",
 		},
 		[]*volume.Volume{},
 	)
@@ -146,7 +157,7 @@ func (d *DuplicityEngine) verify() (err error) {
 			"--no-encryption",
 			"--allow-source-mismatch",
 			"--name", v.Name,
-			v.Target,
+			"%T",
 			v.BackupDir,
 		},
 		[]*volume.Volume{
@@ -191,7 +202,7 @@ func (d *DuplicityEngine) status() (err error) {
 				"--ssh-options", "-oStrictHostKeyChecking=no",
 				"--no-encryption",
 				"--name", v.Name,
-				v.Target,
+				"%T",
 			},
 			[]*volume.Volume{
 				v,
@@ -286,7 +297,7 @@ func (d *DuplicityEngine) launchDuplicity(cmd []string, volumes []*volume.Volume
 		env[k] = v
 	}
 
-	return d.Orchestrator.LaunchContainer(image, env, cmd, volumes)
+	return d.Orchestrator.LaunchContainer(image, env, d.replaceArgs(cmd), volumes)
 }
 
 // duplicityBackup performs the backup of a volume with duplicity
@@ -312,7 +323,7 @@ func (d *DuplicityEngine) duplicityBackup() (err error) {
 			"--allow-source-mismatch",
 			"--name", v.Name,
 			v.BackupDir,
-			v.Target,
+			"%T",
 		},
 		[]*volume.Volume{
 			v,

--- a/engines/duplicity.go
+++ b/engines/duplicity.go
@@ -37,6 +37,7 @@ func (*DuplicityEngine) GetName() string {
 func (d *DuplicityEngine) replaceArgs(args []string) (newArgs []string) {
 	log.Debugf("Replacing args, Input: %v", args)
 	for _, arg := range args {
+		arg = strings.Replace(arg, "%D", d.Volume.BackupDir, -1)
 		arg = strings.Replace(arg, "%T", d.Volume.Target, -1)
 		newArgs = append(newArgs, arg)
 	}
@@ -158,7 +159,7 @@ func (d *DuplicityEngine) verify() (err error) {
 			"--allow-source-mismatch",
 			"--name", v.Name,
 			"%T",
-			v.BackupDir,
+			"%D",
 		},
 		[]*volume.Volume{
 			v,
@@ -322,7 +323,7 @@ func (d *DuplicityEngine) duplicityBackup() (err error) {
 			"--no-encryption",
 			"--allow-source-mismatch",
 			"--name", v.Name,
-			v.BackupDir,
+			"%D",
 			"%T",
 		},
 		[]*volume.Volume{

--- a/engines/duplicity.go
+++ b/engines/duplicity.go
@@ -39,6 +39,8 @@ func (d *DuplicityEngine) replaceArgs(args []string) (newArgs []string) {
 	for _, arg := range args {
 		arg = strings.Replace(arg, "%B", d.Volume.Config.TargetURL, -1)
 		arg = strings.Replace(arg, "%D", d.Volume.BackupDir, -1)
+		arg = strings.Replace(arg, "%H", d.Volume.Hostname, -1)
+		arg = strings.Replace(arg, "%N", d.Volume.Namespace, -1)
 		arg = strings.Replace(arg, "%P", d.Orchestrator.GetPath(d.Volume), -1)
 		arg = strings.Replace(arg, "%T", d.Volume.Target, -1)
 		arg = strings.Replace(arg, "%V", d.Volume.Name, -1)

--- a/engines/duplicity.go
+++ b/engines/duplicity.go
@@ -65,7 +65,7 @@ func (d *DuplicityEngine) Backup() (err error) {
 
 	backupDir := vol.BackupDir
 	c := d.Orchestrator.GetHandler()
-	vol.Target = targetURL.String() + "/" + d.Orchestrator.GetPath(vol)
+	vol.Target = targetURL.String() + "/" + d.Orchestrator.GetPath(vol) + "/" + vol.Name
 	vol.BackupDir = vol.Mountpoint + "/" + backupDir
 	vol.Mount = vol.Name + ":" + vol.Mountpoint + ":ro"
 
@@ -117,7 +117,7 @@ func (d *DuplicityEngine) removeOld() (err error) {
 			"--no-encryption",
 			"--force",
 			"--name", "%V",
-			"%B/%P",
+			"%B/%P/%V",
 		},
 		[]*volume.Volume{},
 	)
@@ -139,7 +139,7 @@ func (d *DuplicityEngine) cleanup() (err error) {
 			"--force",
 			"--extra-clean",
 			"--name", "%V",
-			"%B/%P",
+			"%B/%P/%V",
 		},
 		[]*volume.Volume{},
 	)
@@ -160,7 +160,7 @@ func (d *DuplicityEngine) verify() (err error) {
 			"--no-encryption",
 			"--allow-source-mismatch",
 			"--name", "%V",
-			"%B/%P",
+			"%B/%P/%V",
 			"%D",
 		},
 		[]*volume.Volume{
@@ -205,7 +205,7 @@ func (d *DuplicityEngine) status() (err error) {
 				"--ssh-options", "-oStrictHostKeyChecking=no",
 				"--no-encryption",
 				"--name", "%V",
-				"%B/%P",
+				"%B/%P/%V",
 			},
 			[]*volume.Volume{
 				v,
@@ -326,7 +326,7 @@ func (d *DuplicityEngine) duplicityBackup() (err error) {
 			"--allow-source-mismatch",
 			"--name", "%V",
 			"%D",
-			"%B/%P",
+			"%B/%P/%V",
 		},
 		[]*volume.Volume{
 			v,

--- a/engines/duplicity.go
+++ b/engines/duplicity.go
@@ -2,7 +2,6 @@ package engines
 
 import (
 	"fmt"
-	"net/url"
 	"os"
 	"regexp"
 	"strconv"
@@ -42,7 +41,6 @@ func (d *DuplicityEngine) replaceArgs(args []string) (newArgs []string) {
 		arg = strings.Replace(arg, "%H", d.Volume.Hostname, -1)
 		arg = strings.Replace(arg, "%N", d.Volume.Namespace, -1)
 		arg = strings.Replace(arg, "%P", d.Orchestrator.GetPath(d.Volume), -1)
-		arg = strings.Replace(arg, "%T", d.Volume.Target, -1)
 		arg = strings.Replace(arg, "%V", d.Volume.Name, -1)
 		newArgs = append(newArgs, arg)
 	}
@@ -59,15 +57,8 @@ func (d *DuplicityEngine) Backup() (err error) {
 		"mountpoint": vol.Mountpoint,
 	}).Info("Creating duplicity container")
 
-	targetURL, err := url.Parse(vol.Config.TargetURL)
-	if err != nil {
-		err = fmt.Errorf("failed to parse target URL: %v", err)
-		return
-	}
-
 	backupDir := vol.BackupDir
 	c := d.Orchestrator.GetHandler()
-	vol.Target = targetURL.String() + "/" + d.Orchestrator.GetPath(vol) + "/" + vol.Name
 	vol.BackupDir = vol.Mountpoint + "/" + backupDir
 	vol.Mount = vol.Name + ":" + vol.Mountpoint + ":ro"
 
@@ -312,7 +303,6 @@ func (d *DuplicityEngine) duplicityBackup() (err error) {
 		"name":               v.Name,
 		"backup_dir":         v.BackupDir,
 		"full_if_older_than": v.Config.Duplicity.FullIfOlderThan,
-		"target":             v.Target,
 		"mount":              v.Mount,
 	}).Info("Starting volume backup")
 

--- a/engines/duplicity.go
+++ b/engines/duplicity.go
@@ -37,7 +37,9 @@ func (*DuplicityEngine) GetName() string {
 func (d *DuplicityEngine) replaceArgs(args []string) (newArgs []string) {
 	log.Debugf("Replacing args, Input: %v", args)
 	for _, arg := range args {
+		arg = strings.Replace(arg, "%B", d.Volume.Config.TargetURL, -1)
 		arg = strings.Replace(arg, "%D", d.Volume.BackupDir, -1)
+		arg = strings.Replace(arg, "%P", d.Orchestrator.GetPath(d.Volume), -1)
 		arg = strings.Replace(arg, "%T", d.Volume.Target, -1)
 		arg = strings.Replace(arg, "%V", d.Volume.Name, -1)
 		newArgs = append(newArgs, arg)
@@ -115,7 +117,7 @@ func (d *DuplicityEngine) removeOld() (err error) {
 			"--no-encryption",
 			"--force",
 			"--name", "%V",
-			"%T",
+			"%B/%P",
 		},
 		[]*volume.Volume{},
 	)
@@ -137,7 +139,7 @@ func (d *DuplicityEngine) cleanup() (err error) {
 			"--force",
 			"--extra-clean",
 			"--name", "%V",
-			"%T",
+			"%B/%P",
 		},
 		[]*volume.Volume{},
 	)
@@ -158,7 +160,7 @@ func (d *DuplicityEngine) verify() (err error) {
 			"--no-encryption",
 			"--allow-source-mismatch",
 			"--name", "%V",
-			"%T",
+			"%B/%P",
 			"%D",
 		},
 		[]*volume.Volume{
@@ -203,7 +205,7 @@ func (d *DuplicityEngine) status() (err error) {
 				"--ssh-options", "-oStrictHostKeyChecking=no",
 				"--no-encryption",
 				"--name", "%V",
-				"%T",
+				"%B/%P",
 			},
 			[]*volume.Volume{
 				v,
@@ -324,7 +326,7 @@ func (d *DuplicityEngine) duplicityBackup() (err error) {
 			"--allow-source-mismatch",
 			"--name", "%V",
 			"%D",
-			"%T",
+			"%B/%P",
 		},
 		[]*volume.Volume{
 			v,

--- a/engines/duplicity.go
+++ b/engines/duplicity.go
@@ -39,6 +39,7 @@ func (d *DuplicityEngine) replaceArgs(args []string) (newArgs []string) {
 	for _, arg := range args {
 		arg = strings.Replace(arg, "%D", d.Volume.BackupDir, -1)
 		arg = strings.Replace(arg, "%T", d.Volume.Target, -1)
+		arg = strings.Replace(arg, "%V", d.Volume.Name, -1)
 		newArgs = append(newArgs, arg)
 	}
 	log.Debugf("Replacing args, Output: %v", newArgs)
@@ -113,7 +114,7 @@ func (d *DuplicityEngine) removeOld() (err error) {
 			"--ssh-options", "-oStrictHostKeyChecking=no",
 			"--no-encryption",
 			"--force",
-			"--name", v.Name,
+			"--name", "%V",
 			"%T",
 		},
 		[]*volume.Volume{},
@@ -127,7 +128,6 @@ func (d *DuplicityEngine) removeOld() (err error) {
 
 // cleanup removes old index data from duplicity
 func (d *DuplicityEngine) cleanup() (err error) {
-	v := d.Volume
 	_, _, err = d.launchDuplicity(
 		[]string{
 			"cleanup",
@@ -136,7 +136,7 @@ func (d *DuplicityEngine) cleanup() (err error) {
 			"--no-encryption",
 			"--force",
 			"--extra-clean",
-			"--name", v.Name,
+			"--name", "%V",
 			"%T",
 		},
 		[]*volume.Volume{},
@@ -157,7 +157,7 @@ func (d *DuplicityEngine) verify() (err error) {
 			"--ssh-options", "-oStrictHostKeyChecking=no",
 			"--no-encryption",
 			"--allow-source-mismatch",
-			"--name", v.Name,
+			"--name", "%V",
 			"%T",
 			"%D",
 		},
@@ -202,7 +202,7 @@ func (d *DuplicityEngine) status() (err error) {
 				"--s3-use-new-style",
 				"--ssh-options", "-oStrictHostKeyChecking=no",
 				"--no-encryption",
-				"--name", v.Name,
+				"--name", "%V",
 				"%T",
 			},
 			[]*volume.Volume{
@@ -322,7 +322,7 @@ func (d *DuplicityEngine) duplicityBackup() (err error) {
 			"--ssh-options", "-oStrictHostKeyChecking=no",
 			"--no-encryption",
 			"--allow-source-mismatch",
-			"--name", v.Name,
+			"--name", "%V",
 			"%D",
 			"%T",
 		},

--- a/engines/rclone.go
+++ b/engines/rclone.go
@@ -27,6 +27,7 @@ func (r *RCloneEngine) replaceArgs(args []string) (newArgs []string) {
 	for _, arg := range args {
 		arg = strings.Replace(arg, "%D", r.Volume.BackupDir, -1)
 		arg = strings.Replace(arg, "%T", r.Volume.Target, -1)
+		arg = strings.Replace(arg, "%V", r.Volume.Name, -1)
 		newArgs = append(newArgs, arg)
 	}
 	log.Debugf("Replacing args, Output: %v", newArgs)

--- a/engines/rclone.go
+++ b/engines/rclone.go
@@ -25,7 +25,9 @@ func (*RCloneEngine) GetName() string {
 func (r *RCloneEngine) replaceArgs(args []string) (newArgs []string) {
 	log.Debugf("Replacing args, Input: %v", args)
 	for _, arg := range args {
+		arg = strings.Replace(arg, "%B", r.Volume.Config.TargetURL, -1)
 		arg = strings.Replace(arg, "%D", r.Volume.BackupDir, -1)
+		arg = strings.Replace(arg, "%P", r.Orchestrator.GetPath(r.Volume), -1)
 		arg = strings.Replace(arg, "%T", r.Volume.Target, -1)
 		arg = strings.Replace(arg, "%V", r.Volume.Name, -1)
 		newArgs = append(newArgs, arg)
@@ -51,7 +53,7 @@ func (r *RCloneEngine) Backup() (err error) {
 		[]string{
 			"sync",
 			"%D",
-			"%T",
+			"%B/%P",
 		},
 		[]*volume.Volume{
 			v,

--- a/engines/rclone.go
+++ b/engines/rclone.go
@@ -25,6 +25,7 @@ func (*RCloneEngine) GetName() string {
 func (r *RCloneEngine) replaceArgs(args []string) (newArgs []string) {
 	log.Debugf("Replacing args, Input: %v", args)
 	for _, arg := range args {
+		arg = strings.Replace(arg, "%D", r.Volume.BackupDir, -1)
 		arg = strings.Replace(arg, "%T", r.Volume.Target, -1)
 		newArgs = append(newArgs, arg)
 	}
@@ -48,7 +49,7 @@ func (r *RCloneEngine) Backup() (err error) {
 	state, _, err := r.launchRClone(
 		[]string{
 			"sync",
-			v.BackupDir,
+			"%D",
 			"%T",
 		},
 		[]*volume.Volume{

--- a/engines/rclone.go
+++ b/engines/rclone.go
@@ -27,6 +27,8 @@ func (r *RCloneEngine) replaceArgs(args []string) (newArgs []string) {
 	for _, arg := range args {
 		arg = strings.Replace(arg, "%B", r.Volume.Config.TargetURL, -1)
 		arg = strings.Replace(arg, "%D", r.Volume.BackupDir, -1)
+		arg = strings.Replace(arg, "%H", r.Volume.Hostname, -1)
+		arg = strings.Replace(arg, "%N", r.Volume.Namespace, -1)
 		arg = strings.Replace(arg, "%P", r.Orchestrator.GetPath(r.Volume), -1)
 		arg = strings.Replace(arg, "%T", r.Volume.Target, -1)
 		arg = strings.Replace(arg, "%V", r.Volume.Name, -1)

--- a/engines/rclone.go
+++ b/engines/rclone.go
@@ -46,14 +46,14 @@ func (r *RCloneEngine) Backup() (err error) {
 		return
 	}
 
-	v.Target = targetURL.String() + "/" + r.Orchestrator.GetPath(v)
+	v.Target = targetURL.String() + "/" + r.Orchestrator.GetPath(v) + "/" + v.Name
 	v.BackupDir = v.Mountpoint + "/" + v.BackupDir
 
 	state, _, err := r.launchRClone(
 		[]string{
 			"sync",
 			"%D",
-			"%B/%P",
+			"%B/%P/%V",
 		},
 		[]*volume.Volume{
 			v,

--- a/engines/rclone.go
+++ b/engines/rclone.go
@@ -2,7 +2,6 @@ package engines
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -30,7 +29,6 @@ func (r *RCloneEngine) replaceArgs(args []string) (newArgs []string) {
 		arg = strings.Replace(arg, "%H", r.Volume.Hostname, -1)
 		arg = strings.Replace(arg, "%N", r.Volume.Namespace, -1)
 		arg = strings.Replace(arg, "%P", r.Orchestrator.GetPath(r.Volume), -1)
-		arg = strings.Replace(arg, "%T", r.Volume.Target, -1)
 		arg = strings.Replace(arg, "%V", r.Volume.Name, -1)
 		newArgs = append(newArgs, arg)
 	}
@@ -42,13 +40,6 @@ func (r *RCloneEngine) replaceArgs(args []string) (newArgs []string) {
 func (r *RCloneEngine) Backup() (err error) {
 	v := r.Volume
 
-	targetURL, err := url.Parse(v.Config.TargetURL)
-	if err != nil {
-		err = fmt.Errorf("failed to parse target URL: %v", err)
-		return
-	}
-
-	v.Target = targetURL.String() + "/" + r.Orchestrator.GetPath(v) + "/" + v.Name
 	v.BackupDir = v.Mountpoint + "/" + v.BackupDir
 
 	state, _, err := r.launchRClone(

--- a/engines/restic.go
+++ b/engines/restic.go
@@ -44,7 +44,9 @@ func (*ResticEngine) GetName() string {
 func (r *ResticEngine) replaceArgs(args []string) (newArgs []string) {
 	log.Debugf("Replacing args, Input: %v", args)
 	for _, arg := range args {
+		arg = strings.Replace(arg, "%B", r.Volume.Config.TargetURL, -1)
 		arg = strings.Replace(arg, "%D", r.Volume.BackupDir, -1)
+		arg = strings.Replace(arg, "%P", r.Orchestrator.GetPath(r.Volume), -1)
 		arg = strings.Replace(arg, "%T", r.Volume.Target, -1)
 		arg = strings.Replace(arg, "%V", r.Volume.Name, -1)
 		newArgs = append(newArgs, arg)
@@ -112,7 +114,7 @@ func (r *ResticEngine) init() (err error) {
 	state, _, err := r.launchRestic(
 		[]string{
 			"-r",
-			"%T",
+			"%B/%P",
 			"snapshots",
 		},
 		[]*volume.Volume{},
@@ -132,7 +134,7 @@ func (r *ResticEngine) init() (err error) {
 	state, _, err = r.launchRestic(
 		[]string{
 			"-r",
-			"%T",
+			"%B/%P",
 			"init",
 		},
 		[]*volume.Volume{
@@ -159,7 +161,7 @@ func (r *ResticEngine) resticBackup() (err error) {
 			"--hostname",
 			c.Hostname,
 			"-r",
-			"%T",
+			"%B/%P",
 			"backup",
 			"%D",
 		},
@@ -192,7 +194,7 @@ func (r *ResticEngine) verify() (err error) {
 	state, _, err := r.launchRestic(
 		[]string{
 			"-r",
-			"%T",
+			"%B/%P",
 			"check",
 		},
 		[]*volume.Volume{},
@@ -284,7 +286,7 @@ func (r *ResticEngine) forget() (err error) {
 	state, output, err := r.launchRestic(
 		[]string{
 			"-r",
-			"%T",
+			"%B/%P",
 			"forget",
 			"--prune",
 			"--keep-last",
@@ -309,7 +311,7 @@ func (r *ResticEngine) snapshots() (snapshots []Snapshot, err error) {
 	_, output, err := r.launchRestic(
 		[]string{
 			"-r",
-			"%T",
+			"%B/%P",
 			"snapshots",
 			"--json",
 		},

--- a/engines/restic.go
+++ b/engines/restic.go
@@ -46,6 +46,8 @@ func (r *ResticEngine) replaceArgs(args []string) (newArgs []string) {
 	for _, arg := range args {
 		arg = strings.Replace(arg, "%B", r.Volume.Config.TargetURL, -1)
 		arg = strings.Replace(arg, "%D", r.Volume.BackupDir, -1)
+		arg = strings.Replace(arg, "%H", r.Volume.Hostname, -1)
+		arg = strings.Replace(arg, "%N", r.Volume.Namespace, -1)
 		arg = strings.Replace(arg, "%P", r.Orchestrator.GetPath(r.Volume), -1)
 		arg = strings.Replace(arg, "%T", r.Volume.Target, -1)
 		arg = strings.Replace(arg, "%V", r.Volume.Name, -1)

--- a/engines/restic.go
+++ b/engines/restic.go
@@ -67,7 +67,7 @@ func (r *ResticEngine) Backup() (err error) {
 	}
 
 	c := r.Orchestrator.GetHandler()
-	v.Target = targetURL.String() + "/" + r.Orchestrator.GetPath(v)
+	v.Target = targetURL.String() + "/" + r.Orchestrator.GetPath(v) + "/" + v.Name
 	v.BackupDir = v.Mountpoint + "/" + v.BackupDir
 	v.Mount = v.Name + ":" + v.Mountpoint + ":ro"
 
@@ -114,7 +114,7 @@ func (r *ResticEngine) init() (err error) {
 	state, _, err := r.launchRestic(
 		[]string{
 			"-r",
-			"%B/%P",
+			"%B/%P/%V",
 			"snapshots",
 		},
 		[]*volume.Volume{},
@@ -134,7 +134,7 @@ func (r *ResticEngine) init() (err error) {
 	state, _, err = r.launchRestic(
 		[]string{
 			"-r",
-			"%B/%P",
+			"%B/%P/%V",
 			"init",
 		},
 		[]*volume.Volume{
@@ -161,7 +161,7 @@ func (r *ResticEngine) resticBackup() (err error) {
 			"--hostname",
 			c.Hostname,
 			"-r",
-			"%B/%P",
+			"%B/%P/%V",
 			"backup",
 			"%D",
 		},
@@ -194,7 +194,7 @@ func (r *ResticEngine) verify() (err error) {
 	state, _, err := r.launchRestic(
 		[]string{
 			"-r",
-			"%B/%P",
+			"%B/%P/%V",
 			"check",
 		},
 		[]*volume.Volume{},
@@ -286,7 +286,7 @@ func (r *ResticEngine) forget() (err error) {
 	state, output, err := r.launchRestic(
 		[]string{
 			"-r",
-			"%B/%P",
+			"%B/%P/%V",
 			"forget",
 			"--prune",
 			"--keep-last",
@@ -311,7 +311,7 @@ func (r *ResticEngine) snapshots() (snapshots []Snapshot, err error) {
 	_, output, err := r.launchRestic(
 		[]string{
 			"-r",
-			"%B/%P",
+			"%B/%P/%V",
 			"snapshots",
 			"--json",
 		},

--- a/engines/restic.go
+++ b/engines/restic.go
@@ -46,6 +46,7 @@ func (r *ResticEngine) replaceArgs(args []string) (newArgs []string) {
 	for _, arg := range args {
 		arg = strings.Replace(arg, "%D", r.Volume.BackupDir, -1)
 		arg = strings.Replace(arg, "%T", r.Volume.Target, -1)
+		arg = strings.Replace(arg, "%V", r.Volume.Name, -1)
 		newArgs = append(newArgs, arg)
 	}
 	log.Debugf("Replacing args, Output: %v", newArgs)

--- a/engines/restic.go
+++ b/engines/restic.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -49,7 +48,6 @@ func (r *ResticEngine) replaceArgs(args []string) (newArgs []string) {
 		arg = strings.Replace(arg, "%H", r.Volume.Hostname, -1)
 		arg = strings.Replace(arg, "%N", r.Volume.Namespace, -1)
 		arg = strings.Replace(arg, "%P", r.Orchestrator.GetPath(r.Volume), -1)
-		arg = strings.Replace(arg, "%T", r.Volume.Target, -1)
 		arg = strings.Replace(arg, "%V", r.Volume.Name, -1)
 		newArgs = append(newArgs, arg)
 	}
@@ -62,14 +60,7 @@ func (r *ResticEngine) Backup() (err error) {
 
 	v := r.Volume
 
-	targetURL, err := url.Parse(v.Config.TargetURL)
-	if err != nil {
-		err = fmt.Errorf("failed to parse target URL: %v", err)
-		return
-	}
-
 	c := r.Orchestrator.GetHandler()
-	v.Target = targetURL.String() + "/" + r.Orchestrator.GetPath(v) + "/" + v.Name
 	v.BackupDir = v.Mountpoint + "/" + v.BackupDir
 	v.Mount = v.Name + ":" + v.Mountpoint + ":ro"
 

--- a/engines/restic.go
+++ b/engines/restic.go
@@ -44,6 +44,7 @@ func (*ResticEngine) GetName() string {
 func (r *ResticEngine) replaceArgs(args []string) (newArgs []string) {
 	log.Debugf("Replacing args, Input: %v", args)
 	for _, arg := range args {
+		arg = strings.Replace(arg, "%D", r.Volume.BackupDir, -1)
 		arg = strings.Replace(arg, "%T", r.Volume.Target, -1)
 		newArgs = append(newArgs, arg)
 	}
@@ -159,7 +160,7 @@ func (r *ResticEngine) resticBackup() (err error) {
 			"-r",
 			"%T",
 			"backup",
-			v.BackupDir,
+			"%D",
 		},
 		[]*volume.Volume{
 			v,

--- a/orchestrators/cattle.go
+++ b/orchestrators/cattle.go
@@ -58,7 +58,7 @@ func (*CattleOrchestrator) GetName() string {
 
 // GetPath returns the path of the backup
 func (*CattleOrchestrator) GetPath(v *volume.Volume) string {
-	return v.Hostname + "/" + v.Name
+	return v.Hostname
 }
 
 // GetHandler returns the Orchestrator's handler

--- a/orchestrators/docker.go
+++ b/orchestrators/docker.go
@@ -48,7 +48,7 @@ func (*DockerOrchestrator) GetName() string {
 
 // GetPath returns the path of the backup
 func (*DockerOrchestrator) GetPath(v *volume.Volume) string {
-	return v.Hostname + "/" + v.Name
+	return v.Hostname
 }
 
 // GetHandler returns the Orchestrator's handler

--- a/orchestrators/kubernetes.go
+++ b/orchestrators/kubernetes.go
@@ -53,7 +53,7 @@ func (*KubernetesOrchestrator) GetName() string {
 
 // GetPath returns the path of the backup
 func (*KubernetesOrchestrator) GetPath(v *volume.Volume) string {
-	return v.Namespace + "/" + v.Name
+	return v.Namespace
 }
 
 // GetHandler returns the Orchestrator's handler

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -19,7 +19,6 @@ import (
 type Volume struct {
 	ID             string
 	Name           string
-	Target         string
 	BackupDir      string
 	Mount          string
 	Mountpoint     string

--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -4,7 +4,6 @@ import "testing"
 
 // Set up fake volume
 var fakeVol = Volume{
-	Target:    "/foo",
 	BackupDir: "/back",
 	Mount:     "/mnt",
 	Config:    &Config{},
@@ -14,10 +13,6 @@ var fakeVol = Volume{
 func TestNewVolume(t *testing.T) {
 	fakeVol.Config.Duplicity.FullIfOlderThan = "3W"
 	fakeVol.Config.RemoveOlderThan = "1Y"
-
-	if fakeVol.Target != "/foo" {
-		t.Fatalf("Volume target is wrong. Expected /foo, got %v", fakeVol.Target)
-	}
 
 	if fakeVol.BackupDir != "/back" {
 		t.Fatalf("Volume backup dir is wrong. Expected /back, got %v", fakeVol.BackupDir)


### PR DESCRIPTION
This is a first step to #229.
The idea is to templatize the arguments so that, in the end, we'll be able to launch (not possible yet):
`bivac --restic-backup-args="-r s3:foo/%N/%V"`