### PR TITLE
Don't use deprecated arg in restic command.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ type Config struct {
 
 	Restic struct {
 		CommonArgs string `long:"restic-args" description:"Arguments to pass to restic engine." env:"RESTIC_COMMON_ARGS" default:"-r %B/%P/%V"`
-		BackupArgs string `long:"restic-backup-args" description:"Arguments to pass to restic engine when backup." env:"RESTIC_BACKUP_ARGS" default:"%D --hostname %H"`
+		BackupArgs string `long:"restic-backup-args" description:"Arguments to pass to restic engine when backup." env:"RESTIC_BACKUP_ARGS" default:"%D --host %H"`
 		ForgetArgs string `long:"restic-forget-args" description:"Arguments to pass to restic engine when launching forget." env:"RESTIC_FORGET_ARGS" default:"--keep-daily 15 --prune"`
 		Image      string `long:"restic-image" description:"The restic docker image." env:"RESTIC_DOCKER_IMAGE" default:"restic/restic:latest"`
 		Password   string `long:"restic-password" description:"The restic backup password." env:"RESTIC_PASSWORD"`


### PR DESCRIPTION
Restic reports `Flag --hostname has been deprecated, use --host`.