### PR TITLE
Add label on pods launched by manager

### DIFF
--- a/pkg/orchestrators/kubernetes.go
+++ b/pkg/orchestrators/kubernetes.go
@@ -163,7 +163,7 @@ func (o *KubernetesOrchestrator) DeployAgent(image string, cmd, envs []string, v
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "bivac-agent-",
 			Labels: map[string]string{
-				"generateFromPod": os.Getenv("HOSTNAME"),
+				"generatedFromPod": os.Getenv("HOSTNAME"),
 			},
 		},
 		Spec: apiv1.PodSpec{

--- a/pkg/orchestrators/kubernetes.go
+++ b/pkg/orchestrators/kubernetes.go
@@ -3,6 +3,7 @@ package orchestrators
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -161,6 +162,9 @@ func (o *KubernetesOrchestrator) DeployAgent(image string, cmd, envs []string, v
 	pod, err := o.client.CoreV1().Pods(o.config.Namespace).Create(&apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "bivac-agent-",
+			Labels: map[string]string{
+				"generateFromPod": os.Getenv("HOSTNAME"),
+			},
 		},
 		Spec: apiv1.PodSpec{
 			NodeName:           node,


### PR DESCRIPTION
This PR adds one label on generated pods:
```
generateFromPod=bivac-bivac-xxxxxxxx
```
This labels match the pods name of the manager. This way we can list, delete pods linked to a specific manager:
```
oc get pods -l generateFromPod=bivac-bivac-xxxxxxxx --all-namespaces
```