### PR TITLE
minor/usability: bivac backup/bivac restore needs the volume ID...

### DIFF
--- a/cmd/backup/backup.go
+++ b/cmd/backup/backup.go
@@ -21,7 +21,7 @@ var (
 var envs = make(map[string]string)
 
 var backupCmd = &cobra.Command{
-	Use:   "backup [VOLUME_NAME]",
+	Use:   "backup [VOLUME_ID]",
 	Short: "Backup volumes",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/restore/restore.go
+++ b/cmd/restore/restore.go
@@ -19,7 +19,7 @@ var (
 var envs = make(map[string]string)
 
 var restoreCmd = &cobra.Command{
-	Use:   "restore [VOLUME_NAME]",
+	Use:   "restore [VOLUME_ID]",
 	Short: "Restore volumes",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
...and not the volume name as argument ([naming as proclaimed by "bivac volumes" column headers](https://github.com/camptocamp/bivac/blob/master/cmd/volumes/volumes.go#L41))