### PR TITLE
kubernetes DeployAgent(): copy manager's annotations to agent pod

### DIFF
--- a/contrib/openshift/bivac-template.yaml
+++ b/contrib/openshift/bivac-template.yaml
@@ -77,6 +77,8 @@ objects:
     metadata:
       labels:
         app: ${APP_NAME}
+      annotations:
+        template.alpha.openshift.io/wait-for-ready: "true"
       name: ${APP_NAME}
       namespace: ${NAMESPACE}
     spec:
@@ -99,6 +101,7 @@ objects:
           labels:
             app: ${APP_NAME}
             deploymentconfig: ${APP_NAME}
+          annotations: ${BIVAC_ANNOTATIONS}
         spec:
           dnsPolicy: ClusterFirst
           restartPolicy: Always
@@ -113,7 +116,10 @@ objects:
                 - manager
               imagePullPolicy: IfNotPresent
               name: bivac
-              resources: {}
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 200Mi
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
               env:
@@ -234,3 +240,6 @@ parameters:
   - name: BIVAC_VERBOSE
     description: Enable verbose output (bool)
     value: "true"
+  - name: BIVAC_ANNOTATIONS
+    description: set of annotations for bivac manager, which will be inherited to bivac-agent
+    required: false

--- a/pkg/orchestrators/kubernetes.go
+++ b/pkg/orchestrators/kubernetes.go
@@ -196,10 +196,12 @@ func (o *KubernetesOrchestrator) DeployAgent(image string, cmd, envs []string, v
 		}
 	*/
 
+	if node == "unbound" {
+		node = ""
+	}
+
 	// get manager pod's annotations and copy them to the agent pod
-
 	var namespace = o.config.Namespace
-
 	managerHostname, err := os.Hostname()
 	if err != nil {
 		err = fmt.Errorf("failed to retrieve manager's hostname: %s", err)
@@ -211,22 +213,13 @@ func (o *KubernetesOrchestrator) DeployAgent(image string, cmd, envs []string, v
 		return
 	}
 
-	bivacAgentAnnotations := make(map[string]string)
-	for k, v := range managerPod.ObjectMeta.Annotations {
-		bivacAgentAnnotations[k] = v
-	}
-
-	if node == "unbound" {
-		node = ""
-	}
-
 	pod, err := o.client.CoreV1().Pods(v.Namespace).Create(&apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "bivac-agent-",
 			Labels: map[string]string{
 				"generatedFromPod": os.Getenv("HOSTNAME"),
 			},
-			Annotations: bivacAgentAnnotations,
+			Annotations: managerPod.ObjectMeta.Annotations,
 		},
 		Spec: apiv1.PodSpec{
 			NodeName:           node,

--- a/pkg/orchestrators/kubernetes.go
+++ b/pkg/orchestrators/kubernetes.go
@@ -197,7 +197,8 @@ func (o *KubernetesOrchestrator) DeployAgent(image string, cmd, envs []string, v
 	*/
 
 	// get manager pod's annotations and copy them to the agent pod
-	var namespace string = os.Getenv("KUBERNETES_NAMESPACE")
+
+	var namespace = o.config.Namespace
 
 	managerHostname, err := os.Hostname()
 	if err != nil {


### PR DESCRIPTION
k8s: copy all annotations from bivac-manager pod to bivac-agent pod.
fixes #302 