### PR TITLE
Allow specifying GOARCH and GOOS at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM golang:1.12 as builder
+ARG GOARCH
+ARG GOOS
+ENV GOARCH=$GOARCH \
+	GOOS=$GOOS
 WORKDIR /go/src/github.com/camptocamp/bivac
 COPY . .
 RUN make bivac


### PR DESCRIPTION
Start fixing #322.
This allows to build docker image for non-amd64 ARCH and non-linux OS.
Note: we still have to figure out how to retrieve proper rclone and restic binary.