### PR TITLE
feat: copy securitycontext from manager to agents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.5.1
 	github.com/tatsushid/go-prettytable v0.0.0-20141013043238-ed2d14c29939
-	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 h1:XQyxROzUlZH+WIQwySDgnISg
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/orchestrators/kubernetes.go
+++ b/pkg/orchestrators/kubernetes.go
@@ -224,7 +224,10 @@ func (o *KubernetesOrchestrator) DeployAgent(image string, cmd, envs []string, v
 			RestartPolicy:      "Never",
 			Volumes:            kvs,
 			ServiceAccountName: o.config.AgentServiceAccount,
-			SecurityContext:    managerPod.Spec.SecurityContext,
+			SecurityContext:    &apiv1.PodSecurityContext{
+				SupplementalGroups:        managerPod.Spec.SecurityContext.SupplementalGroups,
+			},
+
 			Containers: []apiv1.Container{
 				{
 					Name:            "bivac-agent",


### PR DESCRIPTION
may fix the errors we still have:
```
.spec.securityContext.seLinuxOptions.level: Invalid value: \"s0:c27,c14\": must be s0:c30,c15, 
.spec.securityContext.seLinuxOptions.level: Invalid value: \"s0:c27,c14\": must be s0:c28,c17,
[...]
```